### PR TITLE
Not quoting the scalar "%transip_api.service.class%" starting with th…

### DIFF
--- a/lib/Verschoof/TransipApiBundle/Resources/config/services.yml
+++ b/lib/Verschoof/TransipApiBundle/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
     transip_api:
-        class: %transip_api.service.class%
+        class: "%transip_api.service.class%"
         arguments:
             transip_config: "%transip_api%"


### PR DESCRIPTION
…e "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.