### PR TITLE
Add Abandoned key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,6 @@
     },
     "autoload": {
         "psr-0": { "Verschoof\\TransipApiBundle\\": "lib/" }
-    }
+    },
+    "abandoned": "transip/transip-api-symfony"
 }


### PR DESCRIPTION
It was already marked as abandoned on Packagist. https://packagist.org/packages/transip/transip-api-symfony has just been made public and we could instead point to this package now. 

I'm not sure if you want to merge it, feel free to not do it. Also, I'm unsure if this will be automatically updated on Packagist. 